### PR TITLE
Add quantum autoencoder using Pennylane for anomaly detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # Quantum-Autoencoders-for-LHC-anomaly-detection
+
+## Introduction
+
+This repository contains code and files related to building a quantum autoencoder using Pennylane and using reconstruction error for anomaly detection. The quantum autoencoder is trained on a dataset and then used to reconstruct signals. The reconstruction error is used to detect anomalies in the signals.
+
+## Requirements
+
+To install the required packages, run:
+```
+pip install -r requirements.txt
+```
+
+## Usage
+
+### Training the Quantum Autoencoder
+
+1. Load the training and signal datasets using the `data_loader` module.
+2. Initialize the quantum autoencoder using the `QuantumAutoencoder` class from the `quantum_autoencoder_circuit` module.
+3. Train the quantum autoencoder on the training dataset using the `training.py` script.
+4. Save the parameters of the trained quantum autoencoder.
+
+### Anomaly Detection
+
+1. Load the training and signal datasets using the `data_loader` module.
+2. Load the parameters of the trained quantum autoencoder.
+3. Reconstruct the signal datasets using the quantum autoencoder.
+4. Calculate the reconstruction error for each signal.
+5. Use the reconstruction errors to plot error distribution histograms and detect anomalies.
+
+## Files
+
+- `requirements.txt`: Contains the required packages for the project.
+- `data_loader.py`: Contains the function to load datasets from h5 files.
+- `quantum_autoencoder_circuit.py`: Contains the implementation of the quantum autoencoder using Pennylane.
+- `training.py`: Script to train the quantum autoencoder on the training dataset.
+- `reconstruct.py`: Script to reconstruct the signal datasets and calculate the reconstruction error.
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/data_loader.py
+++ b/data_loader.py
@@ -1,0 +1,6 @@
+import h5py
+
+def load_h5_dataset(file_path, dataset_name):
+    with h5py.File(file_path, 'r') as file:
+        dataset = file[dataset_name][:]
+    return dataset

--- a/quantum_autoencoder_circuit.py
+++ b/quantum_autoencoder_circuit.py
@@ -1,0 +1,41 @@
+import pennylane as qml
+import numpy as np
+
+class QuantumAutoencoder:
+    def __init__(self, n_qubits, layers, circuit_type='default'):
+        self.n_qubits = n_qubits
+        self.layers = layers
+        self.circuit_type = circuit_type
+        self.dev = qml.device('default.qubit', wires=n_qubits)
+        self.params = np.random.randn(layers, n_qubits, 3)
+
+    def default_circuit(self, params, wires):
+        for i in range(self.layers):
+            for j in range(self.n_qubits):
+                qml.Rot(*params[i, j], wires=wires[j])
+            qml.broadcast(qml.CNOT, wires=wires, pattern="ring")
+
+    def custom_circuit(self, params, wires):
+        for i in range(self.layers):
+            for j in range(self.n_qubits):
+                qml.RX(params[i, j, 0], wires=wires[j])
+                qml.RY(params[i, j, 1], wires=wires[j])
+                qml.RZ(params[i, j, 2], wires=wires[j])
+            qml.broadcast(qml.CZ, wires=wires, pattern="ring")
+
+    def circuit(self, params, wires):
+        if self.circuit_type == 'custom':
+            self.custom_circuit(params, wires)
+        else:
+            self.default_circuit(params, wires)
+
+    def encode(self, x):
+        qml.BasisState(x, wires=range(self.n_qubits))
+
+    def decode(self):
+        return [qml.expval(qml.PauliZ(i)) for i in range(self.n_qubits)]
+
+    def autoencoder_circuit(self, x, params):
+        self.encode(x)
+        self.circuit(params, range(self.n_qubits))
+        return self.decode()

--- a/reconstruct.py
+++ b/reconstruct.py
@@ -1,0 +1,35 @@
+import data_loader
+from quantum_autoencoder_circuit import QuantumAutoencoder
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Load the training and signal datasets
+training_data = data_loader.load_h5_dataset('path_to_training_data.h5', 'training_dataset')
+signal_data = data_loader.load_h5_dataset('path_to_signal_data.h5', 'signal_dataset')
+
+# Initialize the quantum autoencoder
+n_qubits = 4
+layers = 2
+circuit_type = 'default'  # or 'custom'
+autoencoder = QuantumAutoencoder(n_qubits, layers, circuit_type)
+
+# Load the parameters of the trained quantum autoencoder
+params = np.load('path_to_saved_params.npy')
+
+# Define the reconstruction function
+def reconstruct(x, params):
+    return autoencoder.autoencoder_circuit(x, params)
+
+# Calculate the reconstruction error for each signal
+reconstruction_errors = []
+for signal in signal_data:
+    reconstructed_signal = reconstruct(signal, params)
+    error = np.mean((signal - reconstructed_signal) ** 2)
+    reconstruction_errors.append(error)
+
+# Plot the error distribution histograms
+plt.hist(reconstruction_errors, bins=50, alpha=0.75)
+plt.xlabel('Reconstruction Error')
+plt.ylabel('Frequency')
+plt.title('Reconstruction Error Distribution')
+plt.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pennylane
+h5py

--- a/training.py
+++ b/training.py
@@ -1,0 +1,28 @@
+import data_loader
+from quantum_autoencoder_circuit import QuantumAutoencoder
+import numpy as np
+
+# Load the training and signal datasets
+training_data = data_loader.load_h5_dataset('path_to_training_data.h5', 'training_dataset')
+signal_data = data_loader.load_h5_dataset('path_to_signal_data.h5', 'signal_dataset')
+
+# Initialize the quantum autoencoder
+n_qubits = 4
+layers = 2
+circuit_type = 'default'  # or 'custom'
+autoencoder = QuantumAutoencoder(n_qubits, layers, circuit_type)
+
+# Define the cost function
+def cost(params, x):
+    reconstructed = autoencoder.autoencoder_circuit(x, params)
+    return np.mean((x - reconstructed) ** 2)
+
+# Train the quantum autoencoder
+opt = qml.GradientDescentOptimizer(stepsize=0.1)
+epochs = 100
+for epoch in range(epochs):
+    for x in training_data:
+        params = opt.step(lambda v: cost(v, x), autoencoder.params)
+    if epoch % 10 == 0:
+        print(f'Epoch {epoch}: cost = {cost(autoencoder.params, training_data[0])}')
+        np.save(f'params_epoch_{epoch}_{circuit_type}.npy', autoencoder.params)


### PR DESCRIPTION
Add code and files to build a quantum autoencoder using Pennylane and use reconstruction error for anomaly detection.

* **Add `requirements.txt`**: Add `pennylane` and `h5py` to the file.
* **Add `data_loader.py`**: Import `h5py` and define a function `load_h5_dataset` to load datasets from h5 files.
* **Add `quantum_autoencoder_circuit.py`**: Import `pennylane` and `numpy`. Define a quantum autoencoder class using Pennylane, including default and custom quantum circuits.
* **Add `training.py`**: Import `data_loader` and `quantum_autoencoder_circuit`. Load the training and signal datasets using `load_h5_dataset`. Train the quantum autoencoder on the training dataset and save the parameters every few epochs.
* **Modify `README.md`**: Add detailed information about the implementation, including instructions on how to use the quantum autoencoder for anomaly detection.
* **Add `reconstruct.py`**: Import `data_loader` and `quantum_autoencoder_circuit`. Load the training and signal datasets using `load_h5_dataset`. Load the parameters into the quantum circuit, reconstruct the signal datasets, calculate their reconstruction error, and plot error distribution histograms.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/myta12138/Quantum-Autoencoders-for-LHC-anomaly-detection/pull/1?shareId=f94e0fec-5bd1-4ace-8eee-00ee3fbb8638).